### PR TITLE
Jira AT-1180 - change location of noise diode files

### DIFF
--- a/SpectrometerHDF5OutputFile.cpp
+++ b/SpectrometerHDF5OutputFile.cpp
@@ -109,7 +109,7 @@ cSpectrometerHDF5OutputFile::cSpectrometerHDF5OutputFile(const std::string &strF
     H5Pclose(datasetPropertiesStokes);
 
     // Read noise diode data from csv files
-    const string stNdFilesPath = "../../NoiseDiode/";
+    const string stNdFilesPath = "/etc/NoiseDiode/";
     addNoiseDiodeData(stNdFilesPath);
 }
 


### PR DESCRIPTION
Jira AT-1180
The relative path for the noise diode files does not work for docker image. Put it in /etc (similar to ObservatoryInfo.ini previously.