### PR TITLE
Jira AT-1180 - SDB Noise diode sensor was 2 byte sinstead of 1

### DIFF
--- a/SpectrometerHDF5OutputFile.h
+++ b/SpectrometerHDF5OutputFile.h
@@ -50,7 +50,7 @@ class cSpectrometerHDF5OutputFile
     typedef struct cTimestampedChar
     {
         double              m_dTimestamp_s;
-        char                m_chaValue[2];
+        char                m_chaValue[1];
         char                m_chaStatus[8];
     } cTimestampedChar;
 


### PR DESCRIPTION
SpectrometerHDF5OutputFile.h:
Fix noise-diode.roach.on - cTimestampedChar - m_chaValue was 2 bytes instead of 1 - that added a funny character at the end.